### PR TITLE
Implement cookie banner with consent handling

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -27,6 +27,7 @@ import {
   notification,
 } from "antd";
 import DonationDisplay from "./Components/DonationDisplay";
+import CookieBanner from "./Components/CookieBanner";
 import { getTranslation } from "./dictionary";
 
 const App = () => {
@@ -46,6 +47,15 @@ const App = () => {
     useState(true);
   const [autoHideEnabled, setAutoHideEnabled] = useState(false);
   const [uiVisible, setUiVisible] = useState(true);
+  const [cookieConsent, setCookieConsent] = useState(() => {
+    const stored = document.cookie.replace(
+      /(?:(?:^|.*;\s*)cookieConsent\s*=\s*([^;]*).*$)|^.*$/,
+      "$1"
+    );
+    if (stored === "true") return true;
+    if (stored === "false") return false;
+    return null;
+  });
   const autoHideTimeoutRef = React.useRef(null);
 
   const { Title, Text } = Typography;
@@ -70,11 +80,12 @@ const App = () => {
     )
       .then((response) => response.json())
       .then((data) => {
-        const storedVersion =
-          document.cookie.replace(
-            /(?:(?:^|.*;\s*)notificationVersion\s*=\s*([^;]*).*$)|^.*$/,
-            "$1"
-          ) || "0";
+        const storedVersion = cookieConsent
+          ? document.cookie.replace(
+              /(?:(?:^|.*;\s*)notificationVersion\s*=\s*([^;]*).*$)|^.*$/,
+              "$1"
+            ) || "0"
+          : "0";
         if (data.version > parseInt(storedVersion)) {
           notification.info({
             message: data.title || "Neue Features verfügbar!",
@@ -87,11 +98,13 @@ const App = () => {
               <Button
                 size="small"
                 onClick={() => {
-                  document.cookie = `notificationVersion=${
-                    data.version
-                  };path=/;expires=${new Date(
-                    Date.now() + 31536000000
-                  ).toUTCString()}`;
+                  if (cookieConsent) {
+                    document.cookie = `notificationVersion=${
+                      data.version
+                    };path=/;expires=${new Date(
+                      Date.now() + 31536000000
+                    ).toUTCString()}`;
+                  }
                   notification.destroy();
                 }}
               >
@@ -106,7 +119,7 @@ const App = () => {
     return () => {
       clearInterval(apiAvailableInterval);
     };
-  }, []);
+  }, [cookieConsent]);
 
   useEffect(() => {
     // Handle export URL generation
@@ -150,15 +163,35 @@ const App = () => {
     };
   }, [autoHideEnabled, settingsAreVisible]);
 
+  const acceptCookies = () => {
+    document.cookie = `cookieConsent=true;path=/;expires=${new Date(
+      Date.now() + 31536000000
+    ).toUTCString()}`;
+    setCookieConsent(true);
+  };
+
+  const declineCookies = () => {
+    document.cookie = `cookieConsent=false;path=/;expires=${new Date(
+      Date.now() + 31536000000
+    ).toUTCString()}`;
+    setCookieConsent(false);
+    messageApi.open({
+      type: "warning",
+      content: getTranslation(language, "cookiesDeclinedInfo"),
+    });
+  };
+
   const fetchStationData = () => {
     if (urlHasParams()) {
       // fetch data from url
       getUrlParams();
     } else {
-      // fetch data from cookie
-      fetchStationsFromCookie();
-      fetchFontSizeFromCookie();
-      fetchRemarksVisibilityFromCookie();
+      // fetch data from cookie if allowed
+      if (cookieConsent) {
+        fetchStationsFromCookie();
+        fetchFontSizeFromCookie();
+        fetchRemarksVisibilityFromCookie();
+      }
     }
   };
 
@@ -278,6 +311,7 @@ const App = () => {
   };
 
   const fetchRemarksVisibilityFromCookie = () => {
+    if (!cookieConsent) return;
     const cookieRemarksVisibility = document.cookie.replace(
       /(?:(?:^|.*;\s*)remarksVisibility\s*=\s*([^;]*).*$)|^.*$/,
       "$1"
@@ -289,6 +323,7 @@ const App = () => {
   };
 
   const fetchAutoHideFromCookie = () => {
+    if (!cookieConsent) return;
     const cookieAutoHide = document.cookie.replace(
       /(?:(?:^|.*;\s*)autoHide\s*=\s*([^;]*).*$)|^.*$/,
       "$1"
@@ -300,6 +335,7 @@ const App = () => {
   };
 
   const fetchStandardRemarksVisibilityFromCookie = () => {
+    if (!cookieConsent) return;
     const cookieStandardRemarksVisibility = document.cookie.replace(
       /(?:(?:^|.*;\s*)standardRemarksVisibility\s*=\s*([^;]*).*$)|^.*$/,
       "$1"
@@ -314,6 +350,7 @@ const App = () => {
   };
 
   const fetchLanguageFromCookie = () => {
+    if (!cookieConsent) return;
     const cookieLanguage = document.cookie.replace(
       /(?:(?:^|.*;\s*)language\s*=\s*([^;]*).*$)|^.*$/,
       "$1"
@@ -348,6 +385,7 @@ const App = () => {
   };
 
   const fetchFontSizeFromCookie = () => {
+    if (!cookieConsent) return;
     const cookieFontSize = document.cookie.replace(
       /(?:(?:^|.*;\s*)fontSize\s*=\s*([^;]*).*$)|^.*$/,
       "$1"
@@ -362,6 +400,7 @@ const App = () => {
   };
 
   const saveDataInCookie = (propertyName, value) => {
+    if (!cookieConsent) return;
     const cookieValue = `${propertyName}=${JSON.stringify(
       value
     )};path=/;expires=${new Date(Date.now() + 31536000000).toUTCString()}`;
@@ -369,6 +408,7 @@ const App = () => {
   };
 
   const fetchStationsFromCookie = () => {
+    if (!cookieConsent) return;
     const cookieSelectedStations = document.cookie.replace(
       /(?:(?:^|.*;\s*)bvgDepatureSelectedStations\s*=\s*([^;]*).*$)|^.*$/,
       "$1"
@@ -838,6 +878,12 @@ const App = () => {
       >
         <DonationDisplay fontSize={fontSize} language={language} />
       </div>
+      <CookieBanner
+        visible={cookieConsent === null}
+        onAccept={acceptCookies}
+        onDecline={declineCookies}
+        language={language}
+      />
     </div>
   );
 };

--- a/src/Components/CookieBanner.js
+++ b/src/Components/CookieBanner.js
@@ -1,0 +1,40 @@
+import React from "react";
+import { Button } from "antd";
+import { getTranslation } from "../dictionary";
+
+const CookieBanner = ({ visible, onAccept, onDecline, language }) => {
+  if (!visible) return null;
+
+  return (
+    <div
+      style={{
+        position: "fixed",
+        bottom: 0,
+        left: 0,
+        right: 0,
+        padding: "16px",
+        backgroundColor: "#fff",
+        boxShadow: "0px -2px 5px rgba(0,0,0,0.3)",
+        zIndex: 1000,
+      }}
+    >
+      <div style={{ marginBottom: "8px" }}>
+        {getTranslation(language, "cookieBannerText")}
+      </div>
+      <div style={{ display: "flex", justifyContent: "flex-end" }}>
+        <Button
+          type="primary"
+          onClick={onAccept}
+          style={{ marginRight: "8px" }}
+        >
+          {getTranslation(language, "acceptCookies")}
+        </Button>
+        <Button onClick={onDecline}>
+          {getTranslation(language, "declineCookies")}
+        </Button>
+      </div>
+    </div>
+  );
+};
+
+export default CookieBanner;

--- a/src/dictionary.js
+++ b/src/dictionary.js
@@ -36,6 +36,12 @@ const dictionary = {
     searchStation: "Station suchen",
     close: "Schließen",
     provideStationName: "Bitte gib den Namen einer Station ein:",
+    cookieBannerText:
+      "Diese Website verwendet Cookies, um deine Einstellungen zu speichern. Wenn du keine Cookies zulässt, funktionieren einige Funktionen nicht.",
+    acceptCookies: "Cookies akzeptieren",
+    declineCookies: "Cookies ablehnen",
+    cookiesDeclinedInfo:
+      "Du hast Cookies abgelehnt. Deine Einstellungen werden nicht gespeichert.",
   },
   en: {
     line: "Line",
@@ -73,6 +79,12 @@ const dictionary = {
     searchStation: "Search station",
     close: "Close",
     provideStationName: "Please provide the name of a station:",
+    cookieBannerText:
+      "This website uses cookies to store your settings. If you decline cookies some features will not work.",
+    acceptCookies: "Accept cookies",
+    declineCookies: "Decline cookies",
+    cookiesDeclinedInfo:
+      "You declined cookies. Your settings will not be stored.",
   },
 };
 


### PR DESCRIPTION
## Summary
- add translations for cookie banner in German and English
- create `CookieBanner` component
- track and store user cookie consent in `App`
- guard cookie reads/writes behind consent
- display the cookie banner when no consent decision was given
- refactor: move cookie handler functions below `useEffect`

## Testing
- `npm install`
- `npm test --silent -- --watchAll=false --passWithNoTests`


------
https://chatgpt.com/codex/tasks/task_e_684060d69994832aacde881af21cd73c