### PR TITLE
Add Jest testing setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,14 @@ npm run build
 ```
 The output will be placed in the `build/` directory. The repository contains a GitHub Actions workflow that deploys this folder via FTP whenever changes are pushed to the `main` branch.
 
+### Testing
+This project uses **Jest** together with **React Testing Library**. To run the
+test suite execute:
+
+```bash
+npm test -- --watchAll=false
+```
+
 ## Development
 The React source code lives in the [`src`](./src) directory while static assets such as `index.html` reside in [`public`](./public). Feel free to open issues or pull requests if you want to contribute. Please read our [Code of Conduct](./CODE_OF_CONDUCT.md) before participating.
 

--- a/src/Components/DepartureDisplay.test.js
+++ b/src/Components/DepartureDisplay.test.js
@@ -1,0 +1,73 @@
+beforeAll(() => {
+  if (!window.matchMedia) {
+    window.matchMedia = () => ({
+      matches: false,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    });
+  }
+  if (!global.ResizeObserver) {
+    global.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+});
+import { render, waitFor } from '@testing-library/react';
+import DepartureDisplay from './DepartureDisplay';
+
+const baseStation = {
+  id: '1',
+  value: 'Station',
+  when: 0,
+  results: 1,
+  suburban: true,
+  subway: true,
+  tram: true,
+  bus: true,
+  ferry: true,
+  express: true,
+  regional: true,
+};
+
+beforeEach(() => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      json: () => Promise.resolve({ departures: [] }),
+    })
+  );
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+test('does not fetch when no stations', async () => {
+  render(
+    <DepartureDisplay
+      selectedStations={[]}
+      fontSize={16}
+      remarksVisibility={false}
+      standardRemarksVisibility={false}
+      language="en"
+    />
+  );
+  await waitFor(() => expect(global.fetch).not.toHaveBeenCalled());
+});
+
+test('fetches departures when stations provided', async () => {
+  render(
+    <DepartureDisplay
+      selectedStations={[baseStation]}
+      fontSize={16}
+      remarksVisibility={false}
+      standardRemarksVisibility={false}
+      language="en"
+    />
+  );
+  await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+});

--- a/src/Components/DepartureTable.test.js
+++ b/src/Components/DepartureTable.test.js
@@ -1,0 +1,58 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import DepartureTable from './DepartureTable';
+
+beforeAll(() => {
+  if (!window.matchMedia) {
+    window.matchMedia = () => ({
+      matches: false,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    });
+  }
+});
+
+describe('DepartureTable sorting', () => {
+  const baseProps = {
+    fontSize: 16,
+    remarksVisibility: false,
+    language: 'en',
+  };
+
+  const dataSource = [
+    {
+      key: '1',
+      lineName: 'A',
+      direction: 'Dir1',
+      departureName: 'Station B',
+      when: 3,
+    },
+    {
+      key: '2',
+      lineName: 'B',
+      direction: 'Dir2',
+      departureName: 'Station A',
+      when: 5,
+    },
+  ];
+
+  test('clicking departure name header toggles alphabetical sort', () => {
+    render(<DepartureTable {...baseProps} dataSource={[...dataSource]} />);
+
+    // initial order is sorted by time ascending -> Station B first
+    const rowsBefore = screen.getAllByText(/Station/);
+    expect(rowsBefore[0].textContent).toContain('Station B');
+
+    // click to sort ascending by name -> Station A first
+    fireEvent.click(screen.getByText(/Departure from/i));
+    const rowsAsc = screen.getAllByText(/Station/);
+    expect(rowsAsc[0].textContent).toContain('Station A');
+
+    // click again to sort descending -> Station B first
+    fireEvent.click(screen.getByText(/Departure from/i));
+    const rowsDesc = screen.getAllByText(/Station/);
+    expect(rowsDesc[0].textContent).toContain('Station B');
+  });
+});

--- a/src/Components/DonationDisplay.test.js
+++ b/src/Components/DonationDisplay.test.js
@@ -1,0 +1,32 @@
+import { render, screen, waitFor } from '@testing-library/react';
+import DonationDisplay from './DonationDisplay';
+
+beforeAll(() => {
+  if (!global.ResizeObserver) {
+    global.ResizeObserver = class {
+      observe() {}
+      unobserve() {}
+      disconnect() {}
+    };
+  }
+});
+
+beforeEach(() => {
+  global.fetch = jest.fn(() =>
+    Promise.resolve({
+      json: () => Promise.resolve({ donations: ['Alice', 'Bob'] }),
+    })
+  );
+});
+
+afterEach(() => {
+  jest.resetAllMocks();
+});
+
+test('displays fetched donations in marquee', async () => {
+  render(<DonationDisplay fontSize={16} language="en" />);
+  await waitFor(() => expect(global.fetch).toHaveBeenCalled());
+  await waitFor(() => expect(screen.getAllByText(/Alice/).length).toBeGreaterThan(0));
+  expect(screen.getAllByText(/Alice/).length).toBeGreaterThan(0);
+  expect(screen.getAllByText(/Bob/).length).toBeGreaterThan(0);
+});

--- a/src/Components/Settings.test.js
+++ b/src/Components/Settings.test.js
@@ -1,0 +1,37 @@
+beforeAll(() => {
+  if (!window.matchMedia) {
+    window.matchMedia = () => ({
+      matches: false,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    });
+  }
+});
+import { render, screen, fireEvent } from '@testing-library/react';
+import Settings from './Settings';
+
+test('shows modal when add station button clicked', () => {
+  render(
+    <Settings
+      selectedStations={[]}
+      removeStation={() => {}}
+      onStationEdit={() => {}}
+      onStationSelect={() => {}}
+      onLanguageChange={() => {}}
+      onRemarksVisibilityChange={() => {}}
+      onStandardRemarksVisibilityChange={() => {}}
+      onAutoHideChange={() => {}}
+      settingsClass=""
+      remarksVisibility={false}
+      standardRemarksVisibility={false}
+      language="en"
+      autoHideEnabled={false}
+    />
+  );
+
+  fireEvent.click(screen.getByText('Add station'));
+  expect(screen.getByText('Please provide the name of a station:')).toBeTruthy();
+});

--- a/src/Components/SettingsModal.test.js
+++ b/src/Components/SettingsModal.test.js
@@ -1,0 +1,17 @@
+import { render, screen, fireEvent } from '@testing-library/react';
+import SettingsModal from './SettingsModal';
+
+test('calls setSettingsModalVisible on close', () => {
+  const setVisible = jest.fn();
+  render(
+    <SettingsModal
+      settingsModalVisible={true}
+      setSettingsModalVisible={setVisible}
+      selectedStations={[]}
+      onStationSelect={() => {}}
+      language="en"
+    />
+  );
+  fireEvent.click(screen.getByText('Close'));
+  expect(setVisible).toHaveBeenCalledWith(false);
+});

--- a/src/Components/StationFinder.test.js
+++ b/src/Components/StationFinder.test.js
@@ -1,0 +1,21 @@
+beforeAll(() => {
+  if (!window.matchMedia) {
+    window.matchMedia = () => ({
+      matches: false,
+      addListener: () => {},
+      removeListener: () => {},
+      addEventListener: () => {},
+      removeEventListener: () => {},
+      dispatchEvent: () => false,
+    });
+  }
+});
+import { render, screen } from '@testing-library/react';
+import StationFinder from './StationFinder';
+
+test('renders translated placeholder', () => {
+  render(
+    <StationFinder selectedStations={[]} onSelect={() => {}} allowClear={false} language="en" />
+  );
+  expect(screen.getByText('Search station')).toBeTruthy();
+});

--- a/src/dictionary.test.js
+++ b/src/dictionary.test.js
@@ -1,0 +1,15 @@
+import { getTranslation } from './dictionary';
+
+describe('getTranslation', () => {
+  test('returns german translation when key exists', () => {
+    expect(getTranslation('de', 'line')).toBe('Linie');
+  });
+
+  test('returns english translation when key exists', () => {
+    expect(getTranslation('en', 'departureName')).toBe('Departure from');
+  });
+
+  test('falls back to key when translation missing', () => {
+    expect(getTranslation('de', 'non-existent')).toBe('non-existent');
+  });
+});


### PR DESCRIPTION
## Summary
- add dictionary tests
- add DepartureTable tests
- mention how to run tests in README
- add coverage for remaining components

## Testing
- `npm install`
- `npm test -- --watchAll=false`


------
https://chatgpt.com/codex/tasks/task_e_684064f680e0832a95186f07d61eaba7