### PR TITLE
Avoid mutating dataSource in DepartureTable sorting

### DIFF
--- a/src/Components/DepartureTable.js
+++ b/src/Components/DepartureTable.js
@@ -132,7 +132,7 @@ const DepartureTable = (props) => {
 
   const getSortedData = () => {
     if (sortOrder === "off")
-      return props.dataSource.sort((a, b) => a.when - b.when);
+      return [...props.dataSource].sort((a, b) => a.when - b.when);
 
     return [...props.dataSource].sort((a, b) => {
       const comparison = a[sortField].localeCompare(b[sortField]);

--- a/src/Components/DepartureTable.test.js
+++ b/src/Components/DepartureTable.test.js
@@ -146,4 +146,36 @@ describe('DepartureTable sorting', () => {
     expect(whenDataColumn.className).toContain('ant-col-4');
     expect(whenDataColumn.style.textAlign).toBe('right');
   });
+
+  test('default sorting does not mutate the provided dataSource array', () => {
+    const unsortedDataSource = [
+      {
+        key: '2',
+        lineName: 'B',
+        direction: 'Dir2',
+        departureName: 'Station A',
+        when: 5,
+        tripId: 'trip2',
+        stopId: 'stop2'
+      },
+      {
+        key: '1',
+        lineName: 'A',
+        direction: 'Dir1',
+        departureName: 'Station B',
+        when: 3,
+        tripId: 'trip1',
+        stopId: 'stop1'
+      },
+    ];
+
+    render(<DepartureTable {...baseProps} dataSource={unsortedDataSource} />);
+
+    const renderedRows = screen.getAllByText(/Station/);
+    expect(renderedRows[0].textContent).toContain('Station B');
+    expect(unsortedDataSource.map((item) => item.departureName)).toEqual([
+      'Station A',
+      'Station B',
+    ]);
+  });
 });


### PR DESCRIPTION
Thank you NikBLN for this fun project. I really appreciate your creativity and effort.

This PR fixes a small side effect in `DepartureTable`. When sorting is set to the default mode (`sortOrder === "off"`), the component was calling `.sort()` directly on `props.dataSource`. Since `.sort()` mutates the array in place, rendering the table could reorder the original array passed in by the parent.

This change sorts a copied array instead, so the visible behavior stays the same but the component no longer mutates its input. I also added a test to verify that the default sort still renders correctly without changing the original `dataSource`.