### PR TITLE
Keep Departure in header on a single line

### DIFF
--- a/src/Components/DepartureTable.js
+++ b/src/Components/DepartureTable.js
@@ -203,10 +203,12 @@ const DepartureTable = (props) => {
             </Col>
           )}
           <Col
-            style={{ ...styles.columnName, textAlign: "right" }}
+            style={{ ...styles.columnName, position: "relative" }}
             span={props.hideDepartureCol ? 4 : 2}
           >
-            {getTranslation(props.language, whenHeaderKey)}
+            <span style={{ position: "absolute", right: 0, whiteSpace: "nowrap" }}>
+              {getTranslation(props.language, whenHeaderKey)}
+            </span>
           </Col>
         </Row>
       )}


### PR DESCRIPTION
I noticed the Departure In header (Abfahrt in) wraps to a second line whenever the destination column is shown with a large font size, because that column gets only a small slice of the row. Just adding nowrap was not enough on its own, since browsers ignore right alignment when single line content overflows, so the text would simply spill rightward off screen instead.

This switches that one header cell to position relative and anchors the text to the right edge with absolute positioning. The text now extends leftward into the empty space beside Abfahrt von when the translation is too long to fit, and stays on one line.

Happy to take it in a different direction if you would prefer another approach. Thank you for taking a look.
<img width="916" height="220" alt="Screenshot 2026-05-10 at 19 05 57" src="https://github.com/user-attachments/assets/abbb5df7-ad90-4162-92d9-06407f732952" />
