### PR TITLE
Skip mobile grouping when departure column is hidden

### DIFF
--- a/src/Components/DepartureTable.js
+++ b/src/Components/DepartureTable.js
@@ -156,6 +156,43 @@ const DepartureTable = (props) => {
     return groups;
   };
 
+  const renderMobileRow = (data) => {
+    const remarkText = processRemarks(data.remarks);
+    return (
+      <div key={data.key} style={{ display: "flex", flexDirection: "column" }}>
+        <Row style={styles.dataRow}>
+          <Col style={styles.column} span={4}>
+            {data.lineName}
+          </Col>
+          <Col style={styles.column} span={12}>
+            {data.direction}
+          </Col>
+          <Col style={{ ...styles.column, textAlign: "right" }} span={8}>
+            {data.when == null
+              ? getTranslation(props.language, "cancelled")
+              : data.when > 0
+              ? `${data.when} ${getTranslation(props.language, "minutes")}`
+              : getTranslation(props.language, "now")}
+          </Col>
+        </Row>
+        {remarkText && props.remarksVisibility && (
+          <Marquee
+            speed={30}
+            play={!isPaused}
+            style={styles.marquee}
+            onMouseEnter={() => setIsPaused(true)}
+            onMouseLeave={() => setIsPaused(false)}
+          >
+            <span
+              dangerouslySetInnerHTML={{ __html: sanitizeHTML(remarkText) }}
+              onClick={(e) => e.target.tagName === "A" && e.stopPropagation()}
+            />
+          </Marquee>
+        )}
+      </div>
+    );
+  };
+
   return (
     <div
       style={{
@@ -228,8 +265,9 @@ const DepartureTable = (props) => {
         </Row>
       )}
 
-      {/* Mobile: Grouped view */}
+      {/* Mobile: Grouped view by departure name */}
       {isMobile &&
+        !props.hideDepartureCol &&
         Object.entries(getGroupedData()).map(([groupName, items]) => (
           <div key={groupName}>
             {/* Group Header */}
@@ -266,55 +304,12 @@ const DepartureTable = (props) => {
                 )}
               </span>
             </div>
-            {/* Group Items */}
-            {items.map((data) => {
-              const remarkText = processRemarks(data.remarks);
-              return (
-                <div
-                  key={data.key}
-                  style={{ display: "flex", flexDirection: "column" }}
-                >
-                  <Row style={styles.dataRow}>
-                    <Col style={styles.column} span={4}>
-                      {data.lineName}
-                    </Col>
-                    <Col style={styles.column} span={12}>
-                      {data.direction}
-                    </Col>
-                    <Col
-                      style={{ ...styles.column, textAlign: "right" }}
-                      span={8}
-                    >
-                      {data.when == null
-                        ? getTranslation(props.language, "cancelled")
-                        : data.when > 0
-                          ? `${data.when} ${getTranslation(props.language, "minutes")}`
-                          : getTranslation(props.language, "now")}
-                    </Col>
-                  </Row>
-                  {remarkText && props.remarksVisibility && (
-                    <Marquee
-                      speed={30}
-                      play={!isPaused}
-                      style={styles.marquee}
-                      onMouseEnter={() => setIsPaused(true)}
-                      onMouseLeave={() => setIsPaused(false)}
-                    >
-                      <span
-                        dangerouslySetInnerHTML={{
-                          __html: sanitizeHTML(remarkText),
-                        }}
-                        onClick={(e) =>
-                          e.target.tagName === "A" && e.stopPropagation()
-                        }
-                      />
-                    </Marquee>
-                  )}
-                </div>
-              );
-            })}
+            {items.map(renderMobileRow)}
           </div>
         ))}
+
+      {/* Mobile: Flat view when the departure column is hidden */}
+      {isMobile && props.hideDepartureCol && getSortedData().map(renderMobileRow)}
 
       {/* Desktop: Regular view */}
       {!isMobile &&

--- a/src/Components/DepartureTable.test.js
+++ b/src/Components/DepartureTable.test.js
@@ -178,4 +178,35 @@ describe('DepartureTable sorting', () => {
       'Station B',
     ]);
   });
+
+  describe('mobile rendering', () => {
+    beforeEach(() => {
+      Object.defineProperty(window, 'innerWidth', {
+        writable: true,
+        configurable: true,
+        value: 375,
+      });
+    });
+
+    test('renders a per departure group header by default', () => {
+      render(<DepartureTable {...baseProps} dataSource={[...dataSource]} />);
+
+      expect(screen.getByText(/Departure:\s*Station A/i)).toBeTruthy();
+      expect(screen.getByText(/Departure:\s*Station B/i)).toBeTruthy();
+    });
+
+    test('hideDepartureCol removes the departure group headers on mobile', () => {
+      render(
+        <DepartureTable
+          {...baseProps}
+          hideDepartureCol
+          dataSource={[...dataSource]}
+        />
+      );
+
+      expect(screen.queryByText(/Departure:\s*Station/i)).toBeNull();
+      expect(screen.getByText('3 min')).toBeTruthy();
+      expect(screen.getByText('5 min')).toBeTruthy();
+    });
+  });
 });

--- a/src/Components/DepartureTable.test.js
+++ b/src/Components/DepartureTable.test.js
@@ -137,12 +137,15 @@ describe('DepartureTable sorting', () => {
     expect(screen.queryByText(/Departure from/i)).toBeNull();
 
     const destinationHeaderColumn = screen.getByText(/Direction/i, { selector: '.ant-col' });
-    const whenHeaderColumn = screen.getByText(/^Departure$/i, { selector: '.ant-col' });
+    const whenHeaderText = screen.getByText(/^Departure$/i);
+    const whenHeaderColumn = whenHeaderText.closest('.ant-col');
     const whenDataColumn = screen.getByText('3 min', { selector: '.ant-col' });
 
     expect(destinationHeaderColumn.className).toContain('ant-col-16');
     expect(whenHeaderColumn.className).toContain('ant-col-4');
-    expect(whenHeaderColumn.style.textAlign).toBe('right');
+    expect(whenHeaderColumn.style.position).toBe('relative');
+    expect(whenHeaderText.style.position).toBe('absolute');
+    expect(whenHeaderText.style.right).toBe('0px');
     expect(whenDataColumn.className).toContain('ant-col-4');
     expect(whenDataColumn.style.textAlign).toBe('right');
   });


### PR DESCRIPTION
I noticed on the phone that the mobile view still renders an `Abfahrt: <station>` group header strip for every group even when the Hide departure column setting is on. Since the group label is exactly the piece of info that setting is meant to remove, it felt a little inconsistent with the desktop view, which already collapses the `Abfahrt von` column cleanly in that mode.

This PR skips the grouping when `hideDepartureCol` is true on mobile and renders a flat sorted list instead, sharing the existing row markup. The grouped path stays in place when the setting is off, so the default mobile experience does not change. I pulled the row, column, and marquee bits into a small `renderMobileRow` helper so the two paths can share it without duplication.

I added two tests covering the mobile behavior, one for the default grouped path and one for the new flat path under `hideDepartureCol`.

Happy to take this in a different direction if you would rather keep the grouping and only drop the label, or anything else. Thank you for taking a look.